### PR TITLE
Added off-canvas.css file to main

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "authors": [
     "Ciro Nunes <ciroanunes@gmail.com>"
   ],
-  "main": "off-canvas.js",
+  "main": ["off-canvas.js", "off-canvas.css"],
   "license": "MIT",
   "homepage": "http://angular-off-canvas.cironunes.github.io/",
   "ignore": [


### PR DESCRIPTION
This will include the file with bower-main-files plugin in which you can ignore if you don't need the css but you shouldn't tell what to include, should come in bower.json
